### PR TITLE
fix: combine bundle.js, manifest, and icon into JSON file to enable direct import

### DIFF
--- a/bundle.json.d.ts
+++ b/bundle.json.d.ts
@@ -1,5 +1,6 @@
-declare module "bundle.json" {
-  interface Bundle {
+/* eslint-disable */
+declare module 'bundle.json' {
+  type Bundle = {
     bundle: string;
     icon: string;
     manifest: {
@@ -17,20 +18,20 @@ declare module "bundle.json" {
             filePath: string;
             iconPath: string;
             packageName: string;
-            registry: "https://registry.npmjs.org/";
+            registry: 'https://registry.npmjs.org/';
           };
         };
       };
       initialPermissions: {
         snap_getEntropy: {};
-        "endowment:rpc": {
+        'endowment:rpc': {
           dapps: boolean;
           snaps: boolean;
         };
       };
       manifestVersion: string;
     };
-  }
+  };
 
   const bundle: Bundle;
   export default bundle;

--- a/bundle.json.d.ts
+++ b/bundle.json.d.ts
@@ -1,0 +1,37 @@
+declare module "bundle.json" {
+  interface Bundle {
+    bundle: string;
+    icon: string;
+    manifest: {
+      version: string;
+      description: string;
+      proposedName: string;
+      repository: {
+        type: string;
+        url: string;
+      };
+      source: {
+        shasum: string;
+        location: {
+          npm: {
+            filePath: string;
+            iconPath: string;
+            packageName: string;
+            registry: "https://registry.npmjs.org/";
+          };
+        };
+      };
+      initialPermissions: {
+        snap_getEntropy: {};
+        "endowment:rpc": {
+          dapps: boolean;
+          snaps: boolean;
+        };
+      };
+      manifestVersion: string;
+    };
+  }
+
+  const bundle: Bundle;
+  export default bundle;
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,12 @@
     "./package.json": "./package.json",
     "./snap.manifest.json": "./snap.manifest.json",
     "./images/icon.svg": "./images/icon.svg",
-    "./dist/bundle.js": "./dist/bundle.js"
+    "./dist/bundle.js": "./dist/bundle.js",
+    "./dist/bundle.json": {
+      "import": "./dist/bundle.json",
+      "require": "./dist/bundle.json",
+      "types": "./dist/types/bundle.json.d.ts"
+    }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -31,8 +36,9 @@
     "snap.manifest.json"
   ],
   "scripts": {
-    "build": "mm-snap build",
+    "build": "mm-snap build && yarn bundle-all",
     "build:clean": "yarn clean && yarn build",
+    "bundle-all": "node scripts/bundle-all.js",
     "clean": "rimraf dist",
     "lint": "yarn lint:eslint && yarn lint:constraints && yarn lint:misc --check && yarn lint:changelog",
     "lint:changelog": "auto-changelog validate --prettier",

--- a/scripts/bundle-all.js
+++ b/scripts/bundle-all.js
@@ -1,0 +1,46 @@
+const { readFileSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+// Function to read file contents and return as a string
+function readFileContents(filePath) {
+  try {
+    return readFileSync(filePath, 'utf8');
+  } catch (err) {
+    console.error(`Error reading file from disk: ${filePath}`, err);
+    throw err;
+  }
+}
+
+// Paths to the files
+const bundlePath = require.resolve('../dist/bundle.js');
+const iconPath = require.resolve('../images/icon.svg');
+const manifestPath = require.resolve('../snap.manifest.json');
+const typesPath = require.resolve('../bundle.json.d.ts');
+
+// Read the file contents
+const bundle = readFileContents(bundlePath);
+const icon = readFileContents(iconPath);
+const manifest = JSON.parse(readFileContents(manifestPath));
+const types = readFileContents(typesPath);
+
+// Combine the contents into an object
+const combined = {
+  bundle,
+  icon,
+  manifest
+};
+
+// Path for the output JSON file
+const outputPath = join(__dirname, '..', 'dist/bundle.json');
+// Path for the types
+const outputPathTypes = join(__dirname, '..', 'dist/bundle.json.d.ts');
+
+// Write the combined contents to a JSON file
+try {
+  writeFileSync(outputPath, JSON.stringify(combined, null, 0));
+  writeFileSync(outputPathTypes, types);
+  console.log(`Combined file created successfully at ${outputPath}`);
+} catch (err) {
+  console.error('Error writing combined file to disk:', err);
+  throw err;
+}

--- a/scripts/bundle-all.js
+++ b/scripts/bundle-all.js
@@ -1,13 +1,19 @@
+/* eslint-disable n/no-sync, jsdoc/match-description */
+
 const { readFileSync, writeFileSync } = require('node:fs');
 const { join } = require('node:path');
 
-// Function to read file contents and return as a string
+/**
+ * Read the contents of a file and return as a string.
+ * @param {string} filePath - The path to the file
+ * @returns {string} The file as a string
+ */
 function readFileContents(filePath) {
   try {
     return readFileSync(filePath, 'utf8');
-  } catch (err) {
-    console.error(`Error reading file from disk: ${filePath}`, err);
-    throw err;
+  } catch (error) {
+    console.error(`Error reading file from disk: ${filePath}`, error);
+    throw error;
   }
 }
 
@@ -27,7 +33,7 @@ const types = readFileContents(typesPath);
 const combined = {
   bundle,
   icon,
-  manifest
+  manifest,
 };
 
 // Path for the output JSON file
@@ -40,7 +46,7 @@ try {
   writeFileSync(outputPath, JSON.stringify(combined, null, 0));
   writeFileSync(outputPathTypes, types);
   console.log(`Combined file created successfully at ${outputPath}`);
-} catch (err) {
-  console.error('Error writing combined file to disk:', err);
-  throw err;
+} catch (error) {
+  console.error('Error writing combined file to disk:', error);
+  throw error;
 }


### PR DESCRIPTION
Using this snap as a preinstalled snap in the MetaMask Extension currently requires that the MetaMask Extension stringifies the bundle and icon (the manifest can actually be imported normally via `import` or `require`). Since this snap is now intended to be preinstalled, I think this step should be the responsibility of the snap itself, not the MetaMask Extension's build process.

The MetaMask Extension's build system currently enables `brfs` to transform `readFileSync` calls into inline strings, but this package was supposed to be removed (I forgot to remove it after it was no longer required) as it is slow (and necessarily so, as it must statically analyze every single JavaScript file looking for calls to `fs.read*` so it can then replace them) and I'm on a mission to speed up the build process.

So I came up with this proof-of-concept script mostly to get conversation rolling about ways to solve the `fs.readFile*` issue in the MetaMask Extension.

This script and typescript definition file allows the Metamask Extension to use the `@metamask/message-signing-snap` like this:

```typescript
import type { PreinstalledSnap } from '@metamask/snaps-controllers';
import MessageSigningSnap from '@metamask/message-signing-snap/dist/bundle.json';

const { manifest, icon, bundle } = MessageSigningSnap;

const PREINSTALLED_SNAPS: PreinstalledSnap[] = [];

///: BEGIN:ONLY_INCLUDE_IF(snaps)
PREINSTALLED_SNAPS.push(
  getPreinstalledSnap('@metamask/message-signing-snap', manifest, [
    {
      path: 'images/icon.svg',
      value: icon,
    },
    {
      path: 'dist/bundle.js',
      value: bundle,
    },
  ]),
);

function getPreinstalledSnap(
  npmPackage: string,
  manifest: PreinstalledSnap['manifest'],
  files: PreinstalledSnap['files'],
): PreinstalledSnap {
  return {
    snapId: `npm:${npmPackage}` as PreinstalledSnap['snapId'],
    manifest,
    files,
    removable: false,
  };
}
///: END:ONLY_INCLUDE_IF

Object.freeze(PREINSTALLED_SNAPS);

export default PREINSTALLED_SNAPS;

```

instead of https://github.com/MetaMask/metamask-extension/blob/b7312501875735c6d965ad0bd5fac01d59759905/app/scripts/snaps/preinstalled-snaps.ts#L3-L51


This PR also includes a types definition file for the generated manifest. I've only "tested" this by running `yarn build && yarn pack` , installing the tarball into the extension (something like: `yarn add @metamask/message-signing-snap@file:../message-signing-snap/package.tgz`, ten updating the Extension's `preinstalled-snaps.ts` to the above, then building the extension.

I'd love to pair on this issue so we can push a solution over the line sooner rather than later.

p.s, I've disabled a bunch of linting rules in these files because I don't have time for their nonsense ("JSDoc description does not satisfy the regex pattern"?!?).