### PR TITLE
build: add preinstalled snaps type (better typescript interop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "./snap.manifest.json": "./snap.manifest.json",
     "./images/icon.svg": "./images/icon.svg",
     "./dist/bundle.js": "./dist/bundle.js",
-    "./dist/preinstalled-snap.json": "./dist/preinstalled-snap.json"
+    "./dist/preinstalled-snap.json": {
+      "import": "./dist/preinstalled-snap.json",
+      "types": "./dist/preinstalled-snap.d.ts"
+    }
   },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/scripts/build-preinstalled-snap.js
+++ b/scripts/build-preinstalled-snap.js
@@ -51,7 +51,7 @@ const preinstalledSnap = {
       value: icon,
     },
     {
-      path: 'dist/bundle.svg',
+      path: 'dist/bundle.js',
       value: bundle,
     },
   ],

--- a/scripts/build-preinstalled-snap.js
+++ b/scripts/build-preinstalled-snap.js
@@ -26,19 +26,21 @@ function readFileContents(filePath) {
 const bundlePath = require.resolve('../dist/bundle.js');
 const iconPath = require.resolve('../images/icon.svg');
 const manifestPath = require.resolve('../snap.manifest.json');
+const typesPath = require.resolve('../types/preinstalled-snap.d.ts');
 
 // File Contents
 const bundle = readFileContents(bundlePath);
 const icon = readFileContents(iconPath);
 const manifest = readFileContents(manifestPath);
+const types = readFileContents(typesPath);
 
 const snapId =
-  /** @type {import('./build-preinstalled.snap').PreinstalledSnap['snapId']} */ (
+  /** @type {import('@metamask/snaps-controllers').PreinstalledSnap['snapId']} */ (
     `npm:${packageFile.name}`
   );
 
 /**
- * @type {import('./build-preinstalled.snap').PreinstalledSnap}
+ * @type {import('@metamask/snaps-controllers').PreinstalledSnap}
  */
 const preinstalledSnap = {
   snapId,
@@ -58,8 +60,14 @@ const preinstalledSnap = {
 
 // Write preinstalled-snap file
 try {
+  // Preinstall Snap File
   const outputPath = join(__dirname, '..', 'dist/preinstalled-snap.json');
   writeFileSync(outputPath, JSON.stringify(preinstalledSnap, null, 0));
+
+  // Preinstall Snap Types File
+  const outputPathTypes = join(__dirname, '..', 'dist/preinstalled-snap.d.ts');
+  writeFileSync(outputPathTypes, types);
+
   console.log(
     `[preinstalled-snap] - successfully created preinstalled snap at ${outputPath}`,
   );

--- a/scripts/build-preinstalled.snap.d.ts
+++ b/scripts/build-preinstalled.snap.d.ts
@@ -1,1 +1,0 @@
-export type { PreinstalledSnap } from '@metamask/snaps-controllers';

--- a/types/preinstalled-snap.d.ts
+++ b/types/preinstalled-snap.d.ts
@@ -1,0 +1,4 @@
+import type { PreinstalledSnap } from '@metamask/snaps-controllers';
+
+declare const value: PreinstalledSnap;
+export default value;


### PR DESCRIPTION
Adds a definition file for the preinstalled snap file - this makes it easier for TypeScript Interop