### PR TITLE
fix: use `entropySourceId` param when signing

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/message-signing-snap.git"
   },
   "source": {
-    "shasum": "2jZ1Bhf2RBYSwo3pUo+1ZMCKpx+QLMsWGTeEegh1m+w=",
+    "shasum": "S7GuIolgl6snboWhWpsosuMTSHWcJLXxma5VBIZKiLU=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/entropy-keys.test.ts
+++ b/src/entropy-keys.test.ts
@@ -1,16 +1,22 @@
 import type { ListEntropySourcesResult } from '@metamask/snaps-sdk';
+import { secp256k1 } from '@noble/curves/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
 
 import {
-  getPublicEntropyKey,
   getAllPublicEntropyKeys,
+  getPublicEntropyKey,
   signMessageWithEntropyKey,
 } from './entropy-keys';
 
 const MOCK_PRIVATE_KEY =
   '0xec180de430cef919666c2009b91ca3d3b7f6c471136abc9937fa40b89357bbb9';
-
 const MOCK_PUBLIC_KEY =
   '0x02c291ee55d10abcc46de22b775cb0782b06f386ced8b0d0fccb8007a686bbddad';
+
+const MOCK_PRIVATE_KEY_SRP2 =
+  '0x1111111130cef919666c2009b91ca3d3b7f6c471136abc9937fa40b811111111';
+const MOCK_PUBLIC_KEY_SRP2 =
+  '0x0352d5efbc5060eb6e999eac71aedd37621e5d559e74c42b406b2e73e625f9e3f0';
 
 describe('getPublicEntropyKey() tests', () => {
   it('should return a public key from a known private key', async () => {
@@ -24,7 +30,7 @@ describe('getPublicEntropyKey() tests', () => {
     mockSnapGetEntropy();
 
     const address = await getPublicEntropyKey('mockEntropySourceId');
-    expect(address).toBe(MOCK_PUBLIC_KEY);
+    expect(address).toBe(MOCK_PUBLIC_KEY_SRP2);
   });
 });
 
@@ -32,10 +38,38 @@ describe('signMessageWithEntropyKey() tests', () => {
   it('should sign a message with a known private key', async () => {
     mockSnapGetEntropy();
 
-    const signature = await signMessageWithEntropyKey('hello world');
+    const message = 'hello world';
+    const signature = await signMessageWithEntropyKey(message);
     const EXPECTED_SIGNATURE =
       '0x9499d23f16a2fd8511064f7622e0b0c8430d03fd65fda06c85510dfa33e86490781f39d54e880acb76a2ac5a241ba9e68a6a5bee88960ff918c82a54f002492b';
     expect(signature).toBe(EXPECTED_SIGNATURE);
+    expect(
+      secp256k1.verify(
+        signature.substring(2),
+        sha256(message),
+        MOCK_PUBLIC_KEY.substring(2),
+      ),
+    ).toBe(true);
+  });
+
+  it('signs with the private key from a specific source ID', async () => {
+    mockSnapGetEntropy();
+
+    const message = 'hello world';
+    const signature = await signMessageWithEntropyKey(
+      message,
+      'mockEntropySourceId',
+    );
+    const EXPECTED_SIGNATURE =
+      '0xc7cd8af7ddd59287eee7e99f111e637d3e16add417edab1efd388e2688db77dd6e36f1189e47600eeab49c750d4247c5300dbdfbf1d1fad2b6a970070e5148c7';
+    expect(signature).toBe(EXPECTED_SIGNATURE);
+    expect(
+      secp256k1.verify(
+        signature.substring(2),
+        sha256(message),
+        MOCK_PUBLIC_KEY_SRP2.substring(2),
+      ),
+    ).toBe(true);
   });
 });
 
@@ -48,10 +82,13 @@ describe('getAllPublicEntropyKeys() tests', () => {
 
     const mockSnapRequest = jest
       .fn()
-      .mockImplementation(async (r: { method: string }) => {
+      .mockImplementation(async (r: { method: string; params: any }) => {
         if (r.method === 'snap_listEntropySources') {
           return mockEntropySources;
         } else if (r.method === 'snap_getEntropy') {
+          if (r.params.source === 'id2') {
+            return MOCK_PRIVATE_KEY_SRP2;
+          }
           return MOCK_PRIVATE_KEY;
         }
 
@@ -65,7 +102,7 @@ describe('getAllPublicEntropyKeys() tests', () => {
     const relationshipMap = await getAllPublicEntropyKeys();
     expect(relationshipMap).toStrictEqual([
       ['id1', MOCK_PUBLIC_KEY],
-      ['id2', MOCK_PUBLIC_KEY],
+      ['id2', MOCK_PUBLIC_KEY_SRP2],
     ]);
   });
 });
@@ -73,9 +110,12 @@ describe('getAllPublicEntropyKeys() tests', () => {
 function mockSnapGetEntropy() {
   const mockSnapRequest = jest
     .fn()
-    .mockImplementation(async (r: { method: string }) => {
+    .mockImplementation(async (r: { method: string; params: any }) => {
       if (r.method === 'snap_getEntropy') {
-        return MOCK_PRIVATE_KEY; // return private key
+        if (r.params.source === 'mockEntropySourceId') {
+          return MOCK_PRIVATE_KEY_SRP2;
+        }
+        return MOCK_PRIVATE_KEY;
       }
 
       throw new Error(`TEST ENV - Snap Request was not mocked: ${r.method}`);

--- a/src/entropy-keys.ts
+++ b/src/entropy-keys.ts
@@ -82,12 +82,14 @@ export async function getAllPublicEntropyKeys(): Promise<EntropySourceIdSrpIdMap
 /**
  * Signs a message and returns the signature.
  * @param message - Message to sign.
+ * @param entropySourceId - Optional entropy Source ID following SIP-30.
  * @returns Signed Message String.
  */
 export async function signMessageWithEntropyKey(
   message: string,
+  entropySourceId?: EntropySourceId,
 ): Promise<string> {
-  const privateKey = await getPrivateEntropyKey();
+  const privateKey = await getPrivateEntropyKey(entropySourceId);
 
   // We will create the signature using a sha result from the incoming message
   const shaMessage = sha256(message);


### PR DESCRIPTION
fixes [IDENTITY-61](https://consensyssoftware.atlassian.net/jira/software/projects/IDENTITY/boards/727?selectedIssue=IDENTITY-61)

The existing implementation was not useing this parameter which is needed for Multi-SRP scenarios. All other methods were already using it.
I also enhanced some of the tests to validate `entropySourceId` use for all the publicly used methods.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890

Try to provide a description, images, or anything that helps make it clear the intent of the PR.
Thanks!
-->
