### PR TITLE
feat: generate unique entropy (and keys) for different origins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ node_modules/
 
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
+.idea/
 
 # yarn v3 (w/o zero-install)
 # See: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/message-signing-snap.git"
   },
   "source": {
-    "shasum": "VlVQJxe0PphM5hD6TwqUqSfMzh9v0P47a8PiVOaGNlY=",
+    "shasum": "OJtmUSMVoulMYGKx8TBDpfmky5dz+H/3qexRxQZKAwg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/message-signing-snap.git"
   },
   "source": {
-    "shasum": "S7GuIolgl6snboWhWpsosuMTSHWcJLXxma5VBIZKiLU=",
+    "shasum": "VlVQJxe0PphM5hD6TwqUqSfMzh9v0P47a8PiVOaGNlY=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,6 +3,7 @@ import { hexToBytes } from '@noble/ciphers/utils';
 import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
 
+import { INTERNAL_ORIGINS } from '.';
 import type { EntropySourceIdSrpIdMap } from './types';
 
 describe('onRpcRequest - getPublicKey', () => {
@@ -10,14 +11,61 @@ describe('onRpcRequest - getPublicKey', () => {
     const snap = await installSnap();
     const response = await snap.request({
       method: 'getPublicKey',
+      params: {},
     });
 
     // We cant really test/mock the returned private key, so we can only test the "knowns" features of the public key
     // E.g. length = 68 chars
     // E.g. starts with '0x'
     const result = 'result' in response.response && response.response.result;
-    expect(result?.toString().length).toBe(68);
-    expect(result?.toString().startsWith('0x')).toBe(true);
+    expect(result?.toString()).toMatch(/^0x[0-9a-fA-F]{66}$/u);
+  });
+
+  it('should return the same public key for internal domains', async () => {
+    const snap = await installSnap();
+    const resultsByOrigin = await Promise.all(
+      // NOTE!! we can't test for `undefined` origin, as the snapSimulator will default it to `https://metamask.io`
+      INTERNAL_ORIGINS.map(async (origin) => {
+        return snap.request({
+          method: 'getPublicKey',
+          params: {},
+          origin,
+        });
+      }),
+    );
+    const publicKeys = resultsByOrigin.map(
+      (result) =>
+        'result' in result.response && result.response.result?.toString(),
+    );
+    expect(publicKeys).toHaveLength(INTERNAL_ORIGINS.length);
+    expect(new Set(publicKeys).size).toBe(1);
+    expect(typeof publicKeys[0]).toBe('string');
+    expect(publicKeys[0]).toMatch(/^0x[0-9a-fA-F]{66}$/u);
+  });
+
+  it('should return the different public key for different domains', async () => {
+    const snap = await installSnap();
+    const differentOrigins = ['origin 1', 'origin 2', ''];
+    const resultsByOrigin = await Promise.all(
+      differentOrigins.map(async (origin) => {
+        return snap.request({
+          method: 'getPublicKey',
+          params: {},
+          origin,
+        });
+      }),
+    );
+    const publicKeys = resultsByOrigin.map(
+      (result) =>
+        'result' in result.response && result.response.result?.toString(),
+    );
+    expect(publicKeys).toHaveLength(differentOrigins.length);
+    expect(new Set(publicKeys).size).toBe(differentOrigins.length);
+    publicKeys.forEach((entry) => {
+      expect(entry).toBeDefined();
+      expect(typeof entry).toBe('string');
+      expect(entry).toMatch(/^0x[0-9a-fA-F]{66}$/u);
+    });
   });
 });
 
@@ -41,13 +89,15 @@ describe('onRpcRequest - getAllPublicKeys', () => {
 });
 
 describe('onRpcRequest - signMessage', () => {
-  it('should return a signature that can be verified', async () => {
+  it('should return a signature that can be verified for an internal domain', async () => {
     const snap = await installSnap();
     const MESSAGE = 'metamask:hello world';
 
     // Arrange - get public key
     const publicKeyResponse = await snap.request({
       method: 'getPublicKey',
+      params: {},
+      origin: '',
     });
     const publicKey = ('result' in publicKeyResponse.response &&
       publicKeyResponse.response.result?.toString()) as string;
@@ -56,6 +106,7 @@ describe('onRpcRequest - signMessage', () => {
     const signatureResponse = await snap.request({
       method: 'signMessage',
       params: { message: MESSAGE },
+      origin: 'https://docs.metamask.io', // verifying with another internal domain
     });
     const signature = ('result' in signatureResponse.response &&
       signatureResponse.response.result?.toString()) as string;
@@ -63,6 +114,60 @@ describe('onRpcRequest - signMessage', () => {
     // Assert - validate signature
     expect(signature).toBeDefined();
     expect(verifySignature(signature, MESSAGE, publicKey)).toBe(true);
+  });
+
+  it('should return a signature that can be verified, for a specific domain', async () => {
+    const snap = await installSnap();
+    const MESSAGE = 'metamask:hello world';
+
+    // Arrange - get public key
+    const publicKeyResponse = await snap.request({
+      method: 'getPublicKey',
+      params: {},
+      origin: 'https://example.com',
+    });
+    const publicKey = ('result' in publicKeyResponse.response &&
+      publicKeyResponse.response.result?.toString()) as string;
+
+    // Act - create signature
+    const signatureResponse = await snap.request({
+      method: 'signMessage',
+      params: { message: MESSAGE },
+      origin: 'https://example.com',
+    });
+    const signature = ('result' in signatureResponse.response &&
+      signatureResponse.response.result?.toString()) as string;
+
+    // Assert - validate signature
+    expect(signature).toBeDefined();
+    expect(verifySignature(signature, MESSAGE, publicKey)).toBe(true);
+  });
+
+  it('fails to verify signature for the wrong origin', async () => {
+    const snap = await installSnap();
+    const MESSAGE = 'metamask:hello world';
+
+    // Arrange - get public key
+    const publicKeyResponse = await snap.request({
+      method: 'getPublicKey',
+      params: {},
+      origin: 'https://example.com',
+    });
+    const publicKey = ('result' in publicKeyResponse.response &&
+      publicKeyResponse.response.result?.toString()) as string;
+
+    // Act - create signature
+    const signatureResponse = await snap.request({
+      method: 'signMessage',
+      params: { message: MESSAGE },
+      origin: 'https://counter-example.com',
+    });
+    const signature = ('result' in signatureResponse.response &&
+      signatureResponse.response.result?.toString()) as string;
+
+    // Assert - validate signature
+    expect(signature).toBeDefined();
+    expect(verifySignature(signature, MESSAGE, publicKey)).toBe(false);
   });
 
   it('should fail if invalid message provided', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -96,7 +96,6 @@ describe('onRpcRequest - signMessage', () => {
     // Arrange - get public key
     const publicKeyResponse = await snap.request({
       method: 'getPublicKey',
-      params: {},
       origin: '',
     });
     const publicKey = ('result' in publicKeyResponse.response &&
@@ -123,7 +122,6 @@ describe('onRpcRequest - signMessage', () => {
     // Arrange - get public key
     const publicKeyResponse = await snap.request({
       method: 'getPublicKey',
-      params: {},
       origin: 'https://example.com',
     });
     const publicKey = ('result' in publicKeyResponse.response &&
@@ -150,7 +148,6 @@ describe('onRpcRequest - signMessage', () => {
     // Arrange - get public key
     const publicKeyResponse = await snap.request({
       method: 'getPublicKey',
-      params: {},
       origin: 'https://example.com',
     });
     const publicKey = ('result' in publicKeyResponse.response &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,37 +69,23 @@ export const INTERNAL_ORIGINS = [
  * Creates a salt based on the origin.
  * Metamask internal origins should return `undefined`.
  * @param origin - The origin of the RPC request.
- * @param method - The RPC method being called.
  * @returns The salt used to obtain a domain specific entropy.
  * @internal
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function getSaltByOriginAndMethod(
-  origin: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  method: string,
-): string | undefined {
+export function getSaltByOrigin(origin: string): string | undefined {
   // TODO: use smarter matching here
-  if (isEmpty(origin) || INTERNAL_ORIGINS.includes(origin)) {
+  if (!origin || INTERNAL_ORIGINS.includes(origin)) {
     return undefined;
   }
   return origin;
-}
-
-/**
- * Checks if a value is the empty string, null or undefined.
- * @param value - The value to check.
- * @returns {boolean} Returns true if the value is empty, false otherwise.
- */
-function isEmpty(value: string): boolean {
-  return typeof value === `undefined` || value === null || value === '';
 }
 
 export const onRpcRequest: OnRpcRequestHandler = async ({
   request,
   origin,
 }) => {
-  const salt = getSaltByOriginAndMethod(origin, request.method);
+  const salt = getSaltByOrigin(origin);
   switch (request.method) {
     case 'getPublicKey': {
       const { params } = request;


### PR DESCRIPTION
fixes [IDENTITY-2](https://consensyssoftware.atlassian.net/jira/software/projects/IDENTITY/boards/727?selectedIssue=IDENTITY-2)

This is a BREAKING CHANGE.

The message-signing-snap remains accessible by other origins, but it creates unique keys for every origin.
The entropy used as a private key (and implicitly public keys / signatures / storage_keys / etc ) will be origin specific after this fix.
Backwards compatibility is maintained for the origins we were already using as `initialConnections`; they are treated the same as the empty origin, which represents calls coming from the extension or mobile app.