### PR TITLE
chore(ci): remove unnecessary steps and jobs from GH workflows

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [22.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -82,32 +82,6 @@ jobs:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
       - run: yarn test
-      - name: Require clean working directory
-        shell: bash
-        run: |
-          if ! git diff --exit-code; then
-            echo "Working tree dirty at end of job"
-            exit 1
-          fi
-
-  compatibility-test:
-    name: Compatibility test
-    needs: prepare
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x, 22.x]
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
-        with:
-          is-high-risk-environment: false
-          node-version: ${{ matrix.node-version }}
-      - name: Install dependencies via Yarn
-        run: rm yarn.lock && YARN_ENABLE_IMMUTABLE_INSTALLS=false yarn
-      - run: yarn test
-      - name: Restore lockfile
-        run: git restore yarn.lock
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn --immutable
       - run: yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
@@ -32,6 +31,7 @@ jobs:
           include-hidden-files: true
           path: |
             ./dist
+            ./snap.manifest.json
             ./node_modules/.yarn-state.yml
 
   publish-npm-dry-run:


### PR DESCRIPTION
This PR reduces the node version matrix used for testing and removes the compatibility check job.

Since the output of this repo is a preinstalled snap, it does not function as a regular library so there is no need for a compatibility check with various node versions, nor of testing under different node versions.
We use the MM module template repo as a base, but the next step is to adapt that to individual needs, which this PR attempts to do.

This should also reduce the number of conflicts on the manifest shasum.
