### PR TITLE
fix: MetaMask internal calls now specify `metamask` as origin

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/message-signing-snap.git"
   },
   "source": {
-    "shasum": "PvSYWwnLnrmbJ0EzUrAU3vFcZi5YTQlBlbIeilfyMCw=",
+    "shasum": "p6KXWrEaGnxHAO2WrQXTckCYSUyo553Wg2P4O4X9ez0=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export const INTERNAL_ORIGINS = [
   'https://portfolio-builds.metafi-dev.codefi.network',
   'https://docs.metamask.io',
   'https://developer.metamask.io',
-  '', // calls coming from the extension or mobile app will have an empty origin
+  'metamask', // calls coming from the extension or mobile app will have a preset origin.
 ];
 
 /**


### PR DESCRIPTION
MetaMask internal calls now specify `metamask` as origin instead of the empty string.

see https://github.com/MetaMask/core/pull/5616

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890

Try to provide a description, images, or anything that helps make it clear the intent of the PR.
Thanks!
-->
