### PR TITLE
chore: Update endowment:rpc to allow a snaps and add gator snap to initialConnections

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/message-signing-snap.git"
   },
   "source": {
-    "shasum": "9PUmW+e2a0zBmUPTSifCG+ixfDtLdQx7DK8k0gPHFEg=",
+    "shasum": "+eN4x8N9pWaBqBtmoHRZLnSSLq8mW9nhBWR2B6rE4lw=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -21,13 +21,14 @@
     "https://portfolio.metamask.io": {},
     "https://portfolio-builds.metafi-dev.codefi.network": {},
     "https://docs.metamask.io": {},
-    "https://developer.metamask.io": {}
+    "https://developer.metamask.io": {},
+    "npm:@metamask/gator-permissions-snap": {}
   },
   "initialPermissions": {
     "snap_getEntropy": {},
     "endowment:rpc": {
       "dapps": true,
-      "snaps": false
+      "snaps": true
     }
   },
   "platformVersion": "6.19.0",


### PR DESCRIPTION
## What

Updates the `message signing snap` `endowment:rpc` to allow requests from a Snap and adds [npm:@metamask/gator-permissions-snap](https://www.npmjs.com/package/@metamask/gator-permissions-snap/v/0.2.1) to `initialConnections`.

## Why

The [@metamask/gator-permissions-snap](https://www.npmjs.com/package/@metamask/gator-permissions-snap/v/0.2.1) will make RPC call directly with the `message signing snap` to complete [MetaMask Profile Sync Auth Flow](https://www.npmjs.com/package/@metamask/profile-sync-controller)