### PR TITLE
Update CODEOWNERS to identity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/engineering
+*                                    @MetaMask/identity


### PR DESCRIPTION
## Summary

This pull request updates the CODEOWNER from MetaMask/Engineering to MetaMask/Identity. This is done as part of efforts to reduce the noise caused by having large teams as codeowners, and better attributing ownership to repositories.

The owner property of this repository has also been updated accordingly here: https://github.com/MetaMask/message-signing-snap/custom-properties