### PR TITLE
Chore/add new portfolio domain app metamask io

### DIFF
--- a/snap.manifest.json
+++ b/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/message-signing-snap.git"
   },
   "source": {
-    "shasum": "Cd+pxsCFjLP+jh6NNHDGE92g6b610WeAcjFjy8PKgB8=",
+    "shasum": "Ps/ut/Q037Nq1Ml9R3FTzWB/3eeqPQ7TtnSn4v4hGpg=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",


### PR DESCRIPTION
## Summary

Adds the new Portfolio domain `https://app.metamask.io` to `initialConnections` in snap manifest while maintaining backward compatibility with the existing domain.

## Changes

- Added `https://app.metamask.io` to `initialConnections` 
- Kept `https://portfolio.metamask.io` for backward compatibility
- Updated shasum after rebuild

Fixes https://github.com/MetaMask/message-signing-snap/issues/133